### PR TITLE
Use 2 beams instead of 4 beams. 

### DIFF
--- a/model/model.py
+++ b/model/model.py
@@ -48,7 +48,7 @@ class Model:
     ### Response:
     """
     
-    def forward(self, instruction, temperature=0.1, top_p=0.75, top_k=40, num_beams=4, **kwargs):
+    def forward(self, instruction, temperature=0.1, top_p=0.75, top_k=40, num_beams=2, **kwargs):
         prompt = self.generate_prompt(instruction)
         inputs = self._tokenizer(prompt, return_tensors="pt")
         input_ids = inputs["input_ids"].to("cuda")


### PR DESCRIPTION
Beam decoding increases model generation time. The more beams, the longer generation time. We reduce `num_beams` at runtime to be 2 in this PR instead of 4. 